### PR TITLE
Add environment value adMode to support mock ad

### DIFF
--- a/Sources/EasyAdMobBanner/EasyAdMobBanner.swift
+++ b/Sources/EasyAdMobBanner/EasyAdMobBanner.swift
@@ -43,6 +43,7 @@ class EasyAdMobBannerViewController: UIViewController {
 }
 
 struct EasyBannerRepresentable: UIViewControllerRepresentable {
+    @Environment(\.easyAdMode) private var adMode
     
     @State private var viewWidth: CGFloat = .zero
     private let bannerView = GADBannerView()
@@ -84,8 +85,10 @@ struct EasyBannerRepresentable: UIViewControllerRepresentable {
     
     func loadAd(with width: CGFloat) {
         log("\(#function): width: \(width)")
-        bannerView.adSize = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width)
-        bannerView.load(GADRequest())
+        if adMode == .normal {
+            bannerView.adSize = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width)
+            bannerView.load(GADRequest())
+        }
     }
     
     func makeCoordinator() -> Coordinator {

--- a/Sources/EasyAdMobBanner/EasyAdMobEnvironment.swift
+++ b/Sources/EasyAdMobBanner/EasyAdMobEnvironment.swift
@@ -1,0 +1,24 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Chen Hai Teng on 6/18/24.
+//
+
+import SwiftUI
+
+public enum EasyAdMobMode {
+    case normal
+    case mock
+}
+
+public struct EasyAdMobModeKey: EnvironmentKey {
+    public static var defaultValue: EasyAdMobMode = .normal
+}
+
+public extension EnvironmentValues {
+    var easyAdMode: EasyAdMobMode {
+        get { self[EasyAdMobModeKey.self] }
+        set { self[EasyAdMobModeKey.self] =  newValue }
+    }
+}


### PR DESCRIPTION
Add environment value "easyAdMode" to provide mock mode which can disable reqeustAd in banner.
To enable the mock mock, developer can get better screenshot without Goolge ad's test mode.